### PR TITLE
Fix AC_CHECK_LIB error when building mavlink-router

### DIFF
--- a/recipes-px4/mavlink-router/mavlink-router_2.0.0.bb
+++ b/recipes-px4/mavlink-router/mavlink-router_2.0.0.bb
@@ -11,7 +11,7 @@ SRC_URI += "file://mavlink-router.sh"
 S = "${WORKDIR}/git"
 PR = "r0"
 
-inherit autotools update-rc.d
+inherit autotools pkgconfig update-rc.d
 
 INITSCRIPT_NAME = "mavlink-router"
 INITSCRIPT_PARAMS = "defaults"


### PR DESCRIPTION
The lack of 'inherit pkgconfig' was creating the following
error when building on Ubuntu systems with package 'googletest'
installed:

| configure.ac:57: error: possibly undefined macro: AC_CHECK_LIB
|       If this token and others are legitimate, please use m4_pattern_allow.
|       See the Autoconf documentation.